### PR TITLE
Revert "Bump libp2p-webrtc-star from 0.22.4 to 0.23.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "jest": "^27.0.0",
     "kraken-api": "^1.0.1",
     "libp2p-kad-dht": "^0.23.1",
-    "libp2p-webrtc-star": "^0.23.0",
+    "libp2p-webrtc-star": "^0.22.3",
     "mini-css-extract-plugin": "^2.0.0",
     "node-localstorage": "^2.1.6",
     "node-sessionstorage": "^1.0.0",

--- a/src/core/simple/src/config/common.ts
+++ b/src/core/simple/src/config/common.ts
@@ -9,8 +9,7 @@ const common: any = {
     config: {
       Addresses: {
         Swarm: [
-           '/dns4/wrtc-star2.sjc.dwebops.pub/tcp/443/wss/p2p-websocket-star/',
-          // '/dns4/webrtc-star-1.swaponline.io/tcp/443/wss/p2p-webrtc-star/',
+          '/dns4/webrtc-star-1.swaponline.io/tcp/443/wss/p2p-webrtc-star/',
           // '/dns4/discovery.libp2p.array.io/tcp/9091/wss/p2p-websocket-star',
           //'/dns4/ws-star.discovery.libp2p.io/tcp/443/wss/p2p-websocket-star',
           //'/dns4/secure-beyond-12878.herokuapp.com/tcp/443/wss/p2p-webrtc-star/',


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
#

### Video / screenshot proof
<!-- You can use Ctrl+V -->
